### PR TITLE
update emr.sh to copy rain.txt into our bucket.

### DIFF
--- a/part1/emr.sh
+++ b/part1/emr.sh
@@ -1,14 +1,19 @@
 #!/bin/bash -ex
 
 NAME=part1
+# Change this bucket name to your own.
 BUCKET=temp.cascading.org/impatient
+DATA_FILE=rain.txt
 
+# Upload the JAR file to S3.
 s3cmd put build/libs/impatient.jar s3://$BUCKET/$NAME.jar
+# Upload the data file we want to word count.
+s3cmd put data/$DATA_FILE s3://$BUCKET/$DATA_FILE
 
 elastic-mapreduce --create --name "$NAME" \
   --debug \
   --enable-debugging \
   --log-uri s3n://$BUCKET/logs \
   --jar s3n://$BUCKET/$NAME.jar \
-  --arg s3n://$BUCKET/rain.txt \
+  --arg s3n://$BUCKET/$DATA_FILE \
   --arg s3n://$BUCKET/rain

--- a/part2/emr.sh
+++ b/part2/emr.sh
@@ -1,14 +1,21 @@
 #!/bin/bash -ex
 
 NAME=part2
+# Change this bucket name to your own.
 BUCKET=temp.cascading.org/impatient
+DATA_FILE=rain.txt
 
+# Upload the JAR file to S3.
 s3cmd put build/libs/impatient.jar s3://$BUCKET/$NAME.jar
+# Upload the data file we want to word count.
+s3cmd put data/$DATA_FILE s3://$BUCKET/$DATA_FILE
 
+# a ruby client for elastic mapreduce.
+# see: http://aws.amazon.com/developertools/2264
 elastic-mapreduce --create --name "$NAME" \
   --debug \
   --enable-debugging \
   --log-uri s3n://$BUCKET/logs \
   --jar s3n://$BUCKET/$NAME.jar \
-  --arg s3n://$BUCKET/rain.txt \
+  --arg s3n://$BUCKET/$DATA_FILE \
   --arg s3n://$BUCKET/wc


### PR DESCRIPTION
In running the examples on amazon's elastic mapreduce using the emr.sh script in the repo, I noticed that the data file used in part1 and part2, "rain.txt", isn't copied up to S3. this causes the job to fail.

I've updated the script to put the file on s3 before running the job, and tested by changing the bucket name to one that I own, and running the job.
