### PR TITLE
Updated repo url for gradle-aws-s3-sync

### DIFF
--- a/etc/s3Upload.gradle
+++ b/etc/s3Upload.gradle
@@ -27,10 +27,10 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven{ url 'http://repository-monochromeroad.forge.cloudbees.com/release/' }
+    maven{ url 'http://conjars.org/repo/' }
   }
   dependencies {
-    classpath 'com.monochromeroad.gradle:gradle-aws-s3-sync:0.5'
+    classpath 'thirdparty:gradle-aws-s3-sync:0.5'
   }
 }
 


### PR DESCRIPTION
The repo http://repository-monochromeroad.forge.cloudbees.com/release/ is not a valid anymore.
Was able to run builds after switching to http://conjars.org/repo/.
