### PR TITLE
Bumped cascading to 2.5.4, scalding to 0.10.0, and hadoop to 2.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
-**/build
-**/dot
-**/output
-**/.idea
-**/.gradle
-**/.classpath
-**/.settings
-**/.project
+build/
+bin/
+dot/
+output/
+.idea
+.gradle
+.classpath
+.settings/
+.project
 
 *~
 *.dot
@@ -23,4 +24,3 @@
 gradle.properties
 
 aws.properties
-build

--- a/part1/build.gradle
+++ b/part1/build.gradle
@@ -32,8 +32,8 @@ repositories {
   maven{ url 'http://conjars.org/repo/' }
 }
 
-ext.cascadingVersion = '2.5.2'
-ext.hadoopVersion = '2.2.0'
+ext.cascadingVersion = '2.5.4'
+ext.hadoopVersion = '2.4.0'
 
 dependencies {
   compile( group: 'cascading', name: 'cascading-core', version: cascadingVersion )

--- a/part1/src/main/java/impatient/Main.java
+++ b/part1/src/main/java/impatient/Main.java
@@ -22,8 +22,9 @@ package impatient;
 
 import java.util.Properties;
 
+import cascading.flow.FlowConnector;
 import cascading.flow.FlowDef;
-import cascading.flow.hadoop.HadoopFlowConnector;
+import cascading.flow.hadoop2.Hadoop2MR1FlowConnector;
 import cascading.pipe.Pipe;
 import cascading.property.AppProps;
 import cascading.scheme.hadoop.TextDelimited;
@@ -31,18 +32,14 @@ import cascading.tap.Tap;
 import cascading.tap.hadoop.Hfs;
 
 
-public class
-  Main
-  {
-  public static void
-  main( String[] args )
-    {
+public class Main {
+  public static void main( String[] args ) {
     String inPath = args[ 0 ];
     String outPath = args[ 1 ];
 
     Properties properties = new Properties();
     AppProps.setApplicationJarClass( properties, Main.class );
-    HadoopFlowConnector flowConnector = new HadoopFlowConnector( properties );
+    FlowConnector flowConnector = new Hadoop2MR1FlowConnector( properties );
 
     // create the source tap
     Tap inTap = new Hfs( new TextDelimited( true, "\t" ), inPath );
@@ -60,5 +57,5 @@ public class
 
     // run the flow
     flowConnector.connect( flowDef ).complete();
-    }
   }
+}

--- a/part2/build.gradle
+++ b/part2/build.gradle
@@ -32,8 +32,8 @@ repositories {
   maven{ url 'http://conjars.org/repo/' }
 }
 
-ext.cascadingVersion = '2.5.2'
-ext.hadoopVersion = '2.2.0'
+ext.cascadingVersion = '2.5.4'
+ext.hadoopVersion = '2.4.0'
 
 dependencies {
   compile( group: 'cascading', name: 'cascading-core', version: cascadingVersion )

--- a/part2/src/main/java/impatient/Main.java
+++ b/part2/src/main/java/impatient/Main.java
@@ -23,8 +23,9 @@ package impatient;
 import java.util.Properties;
 
 import cascading.flow.Flow;
+import cascading.flow.FlowConnector;
 import cascading.flow.FlowDef;
-import cascading.flow.hadoop.HadoopFlowConnector;
+import cascading.flow.hadoop2.Hadoop2MR1FlowConnector;
 import cascading.operation.aggregator.Count;
 import cascading.operation.regex.RegexSplitGenerator;
 import cascading.pipe.Each;
@@ -49,7 +50,7 @@ public class
 
     Properties properties = new Properties();
     AppProps.setApplicationJarClass( properties, Main.class );
-    HadoopFlowConnector flowConnector = new HadoopFlowConnector( properties );
+    FlowConnector flowConnector = new Hadoop2MR1FlowConnector( properties );
 
     // create source and sink taps
     Tap docTap = new Hfs( new TextDelimited( true, "\t" ), docPath );

--- a/part3/build.gradle
+++ b/part3/build.gradle
@@ -34,8 +34,8 @@ repositories {
   maven{ url 'http://conjars.org/repo/' }
 }
 
-ext.cascadingVersion = '2.5.2'
-ext.hadoopVersion = '2.2.0'
+ext.cascadingVersion = '2.5.4'
+ext.hadoopVersion = '2.4.0'
 
 dependencies {
   compile( group: 'cascading', name: 'cascading-core', version: cascadingVersion )

--- a/part3/src/main/java/impatient/Main.java
+++ b/part3/src/main/java/impatient/Main.java
@@ -23,8 +23,9 @@ package impatient;
 import java.util.Properties;
 
 import cascading.flow.Flow;
+import cascading.flow.FlowConnector;
 import cascading.flow.FlowDef;
-import cascading.flow.hadoop.HadoopFlowConnector;
+import cascading.flow.hadoop2.Hadoop2MR1FlowConnector;
 import cascading.operation.aggregator.Count;
 import cascading.operation.regex.RegexSplitGenerator;
 import cascading.pipe.Each;
@@ -50,7 +51,7 @@ public class
 
     Properties properties = new Properties();
     AppProps.setApplicationJarClass( properties, Main.class );
-    HadoopFlowConnector flowConnector = new HadoopFlowConnector( properties );
+    FlowConnector flowConnector = new Hadoop2MR1FlowConnector( properties );
 
     // create source and sink taps
     Tap docTap = new Hfs( new TextDelimited( true, "\t" ), docPath );

--- a/part4/build.gradle
+++ b/part4/build.gradle
@@ -34,8 +34,8 @@ repositories {
   maven{ url 'http://conjars.org/repo/' }
 }
 
-ext.cascadingVersion = '2.5.2'
-ext.hadoopVersion = '2.2.0'
+ext.cascadingVersion = '2.5.4'
+ext.hadoopVersion = '2.4.0'
 
 dependencies {
   compile( group: 'cascading', name: 'cascading-core', version: cascadingVersion )

--- a/part4/src/main/java/impatient/Main.java
+++ b/part4/src/main/java/impatient/Main.java
@@ -23,8 +23,9 @@ package impatient;
 import java.util.Properties;
 
 import cascading.flow.Flow;
+import cascading.flow.FlowConnector;
 import cascading.flow.FlowDef;
-import cascading.flow.hadoop.HadoopFlowConnector;
+import cascading.flow.hadoop2.Hadoop2MR1FlowConnector;
 import cascading.operation.aggregator.Count;
 import cascading.operation.regex.RegexFilter;
 import cascading.operation.regex.RegexSplitGenerator;
@@ -54,7 +55,7 @@ public class
 
     Properties properties = new Properties();
     AppProps.setApplicationJarClass( properties, Main.class );
-    HadoopFlowConnector flowConnector = new HadoopFlowConnector( properties );
+    FlowConnector flowConnector = new Hadoop2MR1FlowConnector( properties );
 
     // create source and sink taps
     Tap docTap = new Hfs( new TextDelimited( true, "\t" ), docPath );

--- a/part5/build.gradle
+++ b/part5/build.gradle
@@ -34,8 +34,8 @@ repositories {
   maven{ url 'http://conjars.org/repo/' }
 }
 
-ext.cascadingVersion = '2.5.2'
-ext.hadoopVersion = '2.2.0'
+ext.cascadingVersion = '2.5.4'
+ext.hadoopVersion = '2.4.0'
 
 dependencies {
   compile( group: 'cascading', name: 'cascading-core', version: cascadingVersion )

--- a/part5/src/main/java/impatient/Main.java
+++ b/part5/src/main/java/impatient/Main.java
@@ -23,8 +23,9 @@ package impatient;
 import java.util.Properties;
 
 import cascading.flow.Flow;
+import cascading.flow.FlowConnector;
 import cascading.flow.FlowDef;
-import cascading.flow.hadoop.HadoopFlowConnector;
+import cascading.flow.hadoop2.Hadoop2MR1FlowConnector;
 import cascading.operation.Insert;
 import cascading.operation.expression.ExpressionFunction;
 import cascading.operation.regex.RegexFilter;
@@ -60,7 +61,7 @@ public class
 
     Properties properties = new Properties();
     AppProps.setApplicationJarClass( properties, Main.class );
-    HadoopFlowConnector flowConnector = new HadoopFlowConnector( properties );
+    FlowConnector flowConnector = new Hadoop2MR1FlowConnector( properties );
 
     // create source and sink taps
     Tap docTap = new Hfs( new TextDelimited( true, "\t" ), docPath );

--- a/part6/build.gradle
+++ b/part6/build.gradle
@@ -34,15 +34,16 @@ repositories {
   maven{ url 'http://conjars.org/repo/' }
 }
 
-ext.cascadingVersion = '2.5.2'
-ext.hadoopVersion = '2.2.0'
+ext.cascadingVersion = '2.5.4'
+ext.hadoopVersion = '2.4.0'
+ext.slf4jVersion = '1.7.7'
 
 dependencies {
   compile group: 'cascading', name: 'cascading-core', version: cascadingVersion
   compile group: 'cascading', name: 'cascading-hadoop2-mr1', version: cascadingVersion
-  providedCompile group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: hadoopVersion // resolves issue with jdk1.7
-  providedCompile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.5'
-  providedCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.5'
+  providedCompile group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: hadoopVersion
+  providedCompile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
+  providedCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
 
   testCompile group: 'cascading', name: 'cascading-platform', version: cascadingVersion, classifier: 'tests'
   testCompile group: 'cascading', name: 'cascading-hadoop2-mr1', version: cascadingVersion, classifier: 'tests'
@@ -51,8 +52,8 @@ dependencies {
   testCompile group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: hadoopVersion
   testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion
   testCompile group: 'junit', name: 'junit', version: '4.11'
-  testCompile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.5'
-  testCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.5'
+  testCompile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
+  testCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
 }
 
 jar {

--- a/part6/src/main/java/impatient/Main.java
+++ b/part6/src/main/java/impatient/Main.java
@@ -23,8 +23,9 @@ package impatient;
 import java.util.Properties;
 
 import cascading.flow.Flow;
+import cascading.flow.FlowConnector;
 import cascading.flow.FlowDef;
-import cascading.flow.hadoop.HadoopFlowConnector;
+import cascading.flow.hadoop2.Hadoop2MR1FlowConnector;
 import cascading.operation.AssertionLevel;
 import cascading.operation.Debug;
 import cascading.operation.DebugLevel;
@@ -67,7 +68,7 @@ public class
 
     Properties properties = new Properties();
     AppProps.setApplicationJarClass( properties, Main.class );
-    HadoopFlowConnector flowConnector = new HadoopFlowConnector( properties );
+    FlowConnector flowConnector = new Hadoop2MR1FlowConnector( properties );
 
     // create source and sink taps
     Tap docTap = new Hfs( new TextDelimited( true, "\t" ), docPath );

--- a/part7/build.gradle
+++ b/part7/build.gradle
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat
 
 apply plugin: 'java'
 apply plugin: 'idea'
+apply plugin: 'eclipse'
 
 apply from: "../common/providedCompile.gradle"
 
@@ -33,15 +34,15 @@ repositories {
   maven{ url 'http://conjars.org/repo/' }
 }
 
-ext.cascadingVersion = '2.5.2'
-ext.hadoopVersion = '2.2.0'
+ext.cascadingVersion = '2.5.4'
+ext.hadoopVersion = '2.4.0'
 
 dependencies {
   compile( group: 'cascading', name: 'cascading-core', version: cascadingVersion )
   compile( group: 'cascading', name: 'cascading-hadoop2-mr1', version: cascadingVersion )
-  providedCompile( group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client', version: hadoopVersion )
+  providedCompile( group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: hadoopVersion )
 
-  testCompile( 'junit:junit:4.11.+' )
+  testCompile( 'junit:junit:4.11' )
   testCompile group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: hadoopVersion 
   testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: hadoopVersion 
   testCompile group: 'cascading', name: 'cascading-core', version: cascadingVersion, classifier: 'tests', changing: true

--- a/part8/.gitignore
+++ b/part8/.gitignore
@@ -1,2 +1,0 @@
-project/
-target/

--- a/part8/build.gradle
+++ b/part8/build.gradle
@@ -1,29 +1,56 @@
+/*
+ * Copyright (c) 2007-2013 Concurrent, Inc. All Rights Reserved.
+ *
+ * Project and contact information: http://www.cascading.org/
+ *
+ * This file is part of the Cascading project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 apply plugin: 'scala'
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+
+apply from: "../common/providedCompile.gradle"
 
 archivesBaseName = 'impatient'
 
 repositories {
   mavenLocal()
   mavenCentral()
-  mavenRepo name: 'conjars', url: 'http://conjars.org/repo/'
+  maven{ url 'http://conjars.org/repo/' }
 }
 
-ext.cascadingVersion = '2.1.6'
-ext.hadoopVersion = '1.1.2'
+ext.cascadingVersion = '2.5.4'
+ext.hadoopVersion = '2.4.0'
 
 dependencies {
-  // Scala compiler + related tools, and standard library
-  scalaTools 'org.scala-lang:scala-compiler:2.9.2'
-  compile 'org.scala-lang:scala-library:2.9.2'
+  // Scala standard library; scala tools libraries are inferred from the Scala library on the compile class path
+  compile 'org.scala-lang:scala-library:2.10.4'
 
   // Scalding
-  compile( 'com.twitter:scalding_2.9.2:0.8.1' )
+  compile 'com.twitter:scalding-core_2.10:0.10.0'
+
+  // Apache Hadoop
+  providedCompile( group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: hadoopVersion )
+  providedCompile( group: 'org.apache.hadoop', name: 'hadoop-common', version: hadoopVersion )
 
   // in case you need to add JARs from a local build
   compile fileTree( dir: 'lib', includes: ['*.jar'] )
 
   compile( group: 'cascading', name: 'cascading-core', version: cascadingVersion )
-  compile( group: 'cascading', name: 'cascading-hadoop', version: cascadingVersion )
+  compile( group: 'cascading', name: 'cascading-hadoop2-mr1', version: cascadingVersion )
 }
 
 jar {

--- a/part8/pom.xml
+++ b/part8/pom.xml
@@ -16,28 +16,29 @@
             <id>conjars.org</id>
             <url>http://conjars.org/repo</url>
         </repository>
-        <repository>
-            <id>maven-central</id>
-            <url>http://repo1.maven.org/maven2</url>
-        </repository>
     </repositories>
     <dependencies>
         <dependency>
             <groupId>com.twitter</groupId>
-            <artifactId>scalding_2.9.2</artifactId>
-            <version>0.8.1</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>hadoop-core</artifactId>
-                    <groupId>org.apache.hadoop</groupId>
-                </exclusion>
-            </exclusions>
+            <artifactId>scalding-core_2.10</artifactId>
+            <version>0.10.0</version>
         </dependency>
         <dependency>
-            <artifactId>hadoop-core</artifactId>
             <groupId>org.apache.hadoop</groupId>
-            <version>1.0.3</version>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>2.4.0</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>2.4.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.10.4</version>
         </dependency>
     </dependencies>
     <build>
@@ -45,7 +46,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.6</version>
                 <executions>
                     <execution>
                         <goals>

--- a/part8/src/main/scala/Example3.scala
+++ b/part8/src/main/scala/Example3.scala
@@ -13,12 +13,5 @@ class Example3(args : Args) extends Job(args) {
     token
       .trim
       .toLowerCase
-  }  
-
-  // kudos to Chris Severs for this workaround, when running "fat jars" -
-  // avoids the "ClassNotFoundException cascading.*" exception on a Hadoop cluster
-
-  override def config(implicit mode: Mode): Map[AnyRef, AnyRef] = {
-    super.config(mode) ++ Map("cascading.app.appjar.class" -> classOf[Example3])
   }
 }

--- a/part8/src/main/scala/Example4.scala
+++ b/part8/src/main/scala/Example4.scala
@@ -18,12 +18,5 @@ class Example4(args : Args) extends Job(args) {
     token
       .trim
       .toLowerCase
-  }  
-
-  // kudos to Chris Severs for this workaround, when running "fat jars" -
-  // avoids the "ClassNotFoundException cascading.*" exception on a Hadoop cluster
-
-  override def config(implicit mode: Mode): Map[AnyRef, AnyRef] = {
-    super.config(mode) ++ Map("cascading.app.appjar.class" -> classOf[Example4])
   }
 }


### PR DESCRIPTION
This patch upgrades dependencies (cascading to 2.5.4, scalding to 0.10.0, and hadoop to 2.4.0), and contains few minor tweaks.
