### PR TITLE
Fix for gradle 2

### DIFF
--- a/common/providedCompile.gradle
+++ b/common/providedCompile.gradle
@@ -25,7 +25,7 @@ configurations {
 }
 
 sourceSets {
-  main.compileClasspath += configurations.providedCompile
+  main.compileClasspath += [configurations.providedCompile]
 }
 
 task mappings {
@@ -34,17 +34,17 @@ task mappings {
 
 idea {
   module {
-    scopes.PROVIDED.plus += configurations.providedCompile
+    scopes.PROVIDED.plus += [configurations.providedCompile]
   }
 }
 
 javadoc {
-  classpath += configurations.providedCompile
+  classpath += [configurations.providedCompile]
 }
 
 eclipse {
     classpath{
-        plusConfigurations += configurations.providedCompile
+        plusConfigurations += [configurations.providedCompile]
     }
 }
 


### PR DESCRIPTION
This is a backwards compatible change that allows importing using Gradle 2.x.

See this changelog:
http://gradle.org/docs/2.0/release-notes#+=-operator-changes-that-typically-affect-configuration-of-eclipse-and-idea-plugin

